### PR TITLE
BUG: font family is being overwritten

### DIFF
--- a/src/assets/scss/vuesax/_variables.scss
+++ b/src/assets/scss/vuesax/_variables.scss
@@ -37,7 +37,7 @@ $black: #22292f;
         TYPOGRAPHY
 =========================================================*/
 
-$font-family-sans-serif:  "Montserrat", Helvetica, Arial, sans-serif !default;
+$font-family-sans-serif:  -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji" !default;
 $font-family-serif:       Georgia, "Times New Roman", Times, serif !default;
 
 //** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.


### PR DESCRIPTION
Multiple definitions of font-family at root is causing inconsistent behaviour
with netlify. Pushing commit up to see if setting vuesax to system is a fix

Signed-off-by: Luke Malinowski <lmalinowski@mitre.org>