### PR TITLE
Fixed an error preventing linked inspecjs from working

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -8,6 +8,7 @@ module.exports = {
   plugins: [
     '@babel/proposal-class-properties',
     '@babel/proposal-object-rest-spread',
+    '@babel/plugin-transform-modules-commonjs',
     // '@babel/plugin-proposal-decorators'
   ]
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "check-types": "tsc --strict --noEmit"
   },
   "dependencies": {
+    "@babel/plugin-transform-modules-commonjs": "^7.5.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.19",
     "@fortawesome/free-regular-svg-icons": "^5.9.0",
     "@fortawesome/free-solid-svg-icons": "^5.9.0",


### PR DESCRIPTION
See title.

Now linking should work. Take the following tests to replicate.
**In inspecjs directory:**
```
npm run build
npm link
```
**In heimdall-vue directory:**
First remove inspecjs from package.json
```
rm -rf ./node_modules
npm install
npm link inspecjs
```

Then npm run serve as normal
