### PR TITLE
BUG: Fix #53 by suggesting *.json for file upload

### DIFF
--- a/src/components/FileReader.vue
+++ b/src/components/FileReader.vue
@@ -4,7 +4,7 @@
     icon="FilePlusIcon"
     class="cursor-pointer mt-1 sm:mr-6 mr-2">
     </feather-icon>
-    <input type="file" @change="loadTextFromFile"/>
+    <input type="file" accept=".json,application/json" @change="loadTextFromFile"/>
     <slot></slot>
   </label>
 </template>


### PR DESCRIPTION
Resolve #53 by adding proper html input accept key which specifies only json
should be allowed to upload.

Signed-off-by: Luke Malinowski <lmalinowski@mitre.org>